### PR TITLE
Fixed NPE when using old (pre-fp9) handshake.

### DIFF
--- a/src/main/java/org/red5/client/net/rtmp/OutboundHandshake.java
+++ b/src/main/java/org/red5/client/net/rtmp/OutboundHandshake.java
@@ -137,6 +137,7 @@ public class OutboundHandshake extends RTMPHandshake {
             log.trace("Time and version handshake bytes: {}", Hex.encodeHexString(Arrays.copyOf(handshakeBytes, 8)));
         }
         // get the handshake digest
+        c1 = new byte[Constants.HANDSHAKE_SIZE];
         if (fp9Handshake) {
             // handle encryption setup
             if (useEncryption()) {
@@ -165,7 +166,6 @@ public class OutboundHandshake extends RTMPHandshake {
             }
             digestPosClient = getDigestOffset(algorithm, handshakeBytes, 0);
             log.debug("Client digest position offset: {} algorithm: {}", digestPosClient, algorithm);
-            c1 = new byte[Constants.HANDSHAKE_SIZE];
             System.arraycopy(handshakeBytes, 0, c1, 0, Constants.HANDSHAKE_SIZE);
             calculateDigest(digestPosClient, handshakeBytes, 0, GENUINE_FP_KEY, 30, c1, digestPosClient);
             // local storage of outgoing digest

--- a/src/main/java/org/red5/client/net/rtmp/OutboundHandshake.java
+++ b/src/main/java/org/red5/client/net/rtmp/OutboundHandshake.java
@@ -137,7 +137,6 @@ public class OutboundHandshake extends RTMPHandshake {
             log.trace("Time and version handshake bytes: {}", Hex.encodeHexString(Arrays.copyOf(handshakeBytes, 8)));
         }
         // get the handshake digest
-        c1 = new byte[Constants.HANDSHAKE_SIZE];
         if (fp9Handshake) {
             // handle encryption setup
             if (useEncryption()) {
@@ -172,6 +171,8 @@ public class OutboundHandshake extends RTMPHandshake {
             System.arraycopy(c1, digestPosClient, outgoingDigest, 0, DIGEST_LENGTH);
             log.debug("Client digest: {}", Hex.encodeHexString(outgoingDigest));
             log.debug("Digest is valid: {}", verifyDigest(digestPosClient, c1, RTMPHandshake.GENUINE_FP_KEY, 30));
+        } else {
+            c1 = new byte[Constants.HANDSHAKE_SIZE];
         }
         if (log.isTraceEnabled()) {
             log.trace("C1: {}", Hex.encodeHexString(c1));

--- a/src/main/java/org/red5/client/net/rtmp/OutboundHandshake.java
+++ b/src/main/java/org/red5/client/net/rtmp/OutboundHandshake.java
@@ -137,6 +137,7 @@ public class OutboundHandshake extends RTMPHandshake {
             log.trace("Time and version handshake bytes: {}", Hex.encodeHexString(Arrays.copyOf(handshakeBytes, 8)));
         }
         // get the handshake digest
+        c1 = new byte[Constants.HANDSHAKE_SIZE];        
         if (fp9Handshake) {
             // handle encryption setup
             if (useEncryption()) {
@@ -171,8 +172,6 @@ public class OutboundHandshake extends RTMPHandshake {
             System.arraycopy(c1, digestPosClient, outgoingDigest, 0, DIGEST_LENGTH);
             log.debug("Client digest: {}", Hex.encodeHexString(outgoingDigest));
             log.debug("Digest is valid: {}", verifyDigest(digestPosClient, c1, RTMPHandshake.GENUINE_FP_KEY, 30));
-        } else {
-            c1 = new byte[Constants.HANDSHAKE_SIZE];
         }
         if (log.isTraceEnabled()) {
             log.trace("C1: {}", Hex.encodeHexString(c1));


### PR DESCRIPTION
When running with `-Duse.fp9.handshake=false` client would drop an NPE. With this fix the "random" part will be just a bunch of zeros but it is enough to complete the old-fashined handshake.