### PR TITLE
Add support for RTMPS in the StreamingProxy

### DIFF
--- a/src/main/java/org/red5/proxy/ClientType.java
+++ b/src/main/java/org/red5/proxy/ClientType.java
@@ -1,0 +1,25 @@
+/*
+ * RED5 Open Source Flash Server - https://github.com/Red5/
+ * 
+ * Copyright 2006-2015 by respective authors (see below). All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.red5.proxy;
+
+public enum ClientType {
+
+    RTMP, RTMPS;
+
+}

--- a/src/main/java/org/red5/proxy/StreamingProxy.java
+++ b/src/main/java/org/red5/proxy/StreamingProxy.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Semaphore;
 import org.red5.client.net.rtmp.ClientExceptionHandler;
 import org.red5.client.net.rtmp.INetStreamEventHandler;
 import org.red5.client.net.rtmp.RTMPClient;
+import org.red5.client.net.rtmps.RTMPSClient;
 import org.red5.io.utils.ObjectMap;
 import org.red5.server.api.service.IPendingServiceCall;
 import org.red5.server.api.service.IPendingServiceCallback;
@@ -70,7 +71,20 @@ public class StreamingProxy implements IPushableConsumer, IPipeConnectionListene
     private static Timer timer;
 
     public void init() {
-        rtmpClient = new RTMPClient();
+        init(ClientType.RTMP);
+    }
+
+    public void init(ClientType clientType) {
+        switch (clientType) {
+            case RTMPS:
+                rtmpClient = new RTMPSClient();
+                break;
+            case RTMP:
+            default:
+                rtmpClient = new RTMPClient();
+                break;
+        }
+        log.debug("Initialized: {}", rtmpClient);
         setState(StreamState.STOPPED);
         // create a timer
         timer = new Timer();


### PR DESCRIPTION
This pull request is to add support for RTMPS in the streamingProxy. We have a need for a proxy that can output RTMPS. Facebook for example will only accept RTMPS for live streaming.

I have compiled the code and tested it in our infrastructure to RTMP and RTMPS outputs, both work as expected. 

Cheers! 