### PR TITLE
BaseRTMPClientHandler.onChunkSize:Don't update writeChunkSize

### DIFF
--- a/src/main/java/org/red5/client/net/rtmp/BaseRTMPClientHandler.java
+++ b/src/main/java/org/red5/client/net/rtmp/BaseRTMPClientHandler.java
@@ -347,11 +347,10 @@ public abstract class BaseRTMPClientHandler extends BaseRTMPHandler implements I
     @Override
     protected void onChunkSize(RTMPConnection conn, Channel channel, Header source, ChunkSize chunkSize) {
         log.debug("onChunkSize");
-        // set read and write chunk sizes
+        // chunkSize was updated by peer, update our read-chunksize
         RTMP state = conn.getState();
         state.setReadChunkSize(chunkSize.getSize());
-        state.setWriteChunkSize(chunkSize.getSize());
-        log.info("ChunkSize configured: {}", chunkSize);
+        log.info("Incoming chunkSize configured: {}", chunkSize);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
The RTMP specification states clearly, that "The maximum chunk size is
maintained independently for each direction". That means that our peer
updating its chunkSize, does not affect our outgoing chunkSize. A change
in writeChunkSize must be accompanied by a SetChunkSize message of our own,
otherwise our peer have no reliable way to know what chunksize to use for
each message.

https://rtmp.veriskope.com/docs/spec/?#541set-chunk-size-1